### PR TITLE
Replace duplicate code with new Inputs class which supports outputting the input sequence as binding descriptors

### DIFF
--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -18,20 +18,14 @@ export type BindingFn = () => void;
 export class Binding {
 	fn: BindingFn;
 	value?: number;
-	sequential: boolean = false;
 	keys: string[][];
-	name?: string;
 
 	constructor(
 		keys: string[][],
 		fn: BindingFn,
-		sequential: boolean = false,
-		name?: string,
 	) {
 		this.keys = keys;
 		this.fn = fn;
-		this.name = name;
-		this.sequential = sequential;
 	}
 
 	matches(input: Input[]) {

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -9,7 +9,7 @@ const SEPERATOR_SEQUENTIAL = ">";
 
 type BSeperator = "simultaneous" | "sequential";
 
-/** Internally, inputman represents bindings as a 2D array of strings in which each inner array represents a group of 
+/** Internally, inputman represents bindings as a 2D array of strings in which each inner array represents a group of
  * simultaneous inputs. Multiple arrays then represent sets of simultaneous inputs connected sequentially*/
 export type BindingDescriptor = string[][];
 
@@ -39,15 +39,13 @@ export class Binding {
 	}
 }
 
-export function parseBinding(
-	binding: string,
-): BindingDescriptor {
+export function parseBinding(binding: string): BindingDescriptor {
 	const split = splitBinding(binding);
-	const groups: BindingDescriptor = []
+	const groups: BindingDescriptor = [];
 
 	let curr_group: string[] = [];
 	let idx = 0;
-	for (let w of split) {
+	for (const w of split) {
 		const word = w.trim();
 		if (word === SEPERATOR_SEQUENTIAL) {
 			if (curr_group.length > 0) {
@@ -65,7 +63,7 @@ export function parseBinding(
 		groups.push(curr_group);
 	}
 
-	return groups
+	return groups;
 }
 
 export function parseInputSequence(input: Input[]): BindingDescriptor {
@@ -76,7 +74,10 @@ export function parseInputSequence(input: Input[]): BindingDescriptor {
 
 /** Internal function to check if one binding descriptor (converted from a series of inputs) contains another binding descriptor.
  * Used internally in bindings to check if they match the current input state */
-export function inputContainsOrdered(outer: BindingDescriptor, inner: BindingDescriptor): boolean {
+export function inputContainsOrdered(
+	outer: BindingDescriptor,
+	inner: BindingDescriptor,
+): boolean {
 	return true;
 }
 
@@ -84,14 +85,14 @@ export function splitBinding(binding: string): string[] {
 	const split = [];
 	let currWord: string = "";
 
-	for (let c of binding) {
+	for (const c of binding) {
 		if (c === SEPERATOR_SIMULTANEOUS || c === SEPERATOR_SEQUENTIAL) {
 			if (currWord.length > 0) {
 				split.push(currWord.trim());
 				currWord = "";
 			}
-			split.push(c)
-			continue
+			split.push(c);
+			continue;
 		}
 
 		currWord += c;
@@ -101,7 +102,7 @@ export function splitBinding(binding: string): string[] {
 		split.push(currWord);
 	}
 
-	return split
+	return split;
 }
 
 export function createBinding(
@@ -110,5 +111,5 @@ export function createBinding(
 ): Binding | undefined {
 	const bindingGroups = parseBinding(binding);
 
-	return new Binding(bindingGroups, fn)
+	return new Binding(bindingGroups, fn);
 }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1,8 +1,6 @@
 // Most of this file is concerned with parsing binding strings. I don't trust regexes so we're doing this the old fashioned way.
 
-import type { Key } from "./layers/keyboard";
-import type { Input } from "./manager";
-import { arrayContainsOrd } from "./util";
+import { arrayEqual2d } from "./util";
 
 const SEPERATOR_SIMULTANEOUS = "+";
 const SEPERATOR_SEQUENTIAL = ">";
@@ -18,18 +16,18 @@ export type BindingFn = () => void;
 export class Binding {
 	fn: BindingFn;
 	value?: number;
-	keys: string[][];
+	descriptor: BindingDescriptor;
 
 	constructor(
-		keys: string[][],
+		descriptor: BindingDescriptor,
 		fn: BindingFn,
 	) {
-		this.keys = keys;
+		this.descriptor = descriptor;
 		this.fn = fn;
 	}
 
-	matches(input: Input[]) {
-		return true;
+	matches(input: BindingDescriptor) {
+		return arrayEqual2d(input, this.descriptor);
 	}
 }
 
@@ -58,21 +56,6 @@ export function parseBinding(binding: string): BindingDescriptor {
 	}
 
 	return groups;
-}
-
-export function parseInputSequence(input: Input[]): BindingDescriptor {
-	const ret: string[][] = [];
-
-	return ret;
-}
-
-/** Internal function to check if one binding descriptor (converted from a series of inputs) contains another binding descriptor.
- * Used internally in bindings to check if they match the current input state */
-export function inputContainsOrdered(
-	outer: BindingDescriptor,
-	inner: BindingDescriptor,
-): boolean {
-	return true;
 }
 
 export function splitBinding(binding: string): string[] {

--- a/src/input.ts
+++ b/src/input.ts
@@ -18,20 +18,20 @@ export interface Input<T> {
 /** Describes the configuration for the input class */
 export interface InputConfig {
 	/** How long inputs remain in the release and input sequence */
-	releaseSequenceTimer?: number,
+	releaseSequenceTimer?: number;
 	/** The maximum number of inputs in the release sequence */
-	maxReleaseSequenceLength?: number,
+	maxReleaseSequenceLength?: number;
 	/** The maximum length of the full sequence of both pressed keys and releases */
-	maxInputSequenceLength?: number,
+	maxInputSequenceLength?: number;
 }
 
-/** This class is used internally by both the input manager and the input layers to keep track of the sequence of inputs, 
- * currently pressed inputs, and the sequence in which inputs were released. It also provides code for converting 
+/** This class is used internally by both the input manager and the input layers to keep track of the sequence of inputs,
+ * currently pressed inputs, and the sequence in which inputs were released. It also provides code for converting
  * the sequence of inputs into binding descriptors for binding matches.*/
 export class Inputs<T> {
 	private _inputSequence: Array<Input<T>> = [];
 	private _pressedInputs: Set<T> = new Set();
-	private _releaseSequence: Array<T> = new Array();
+	private _releaseSequence: Array<T> = [];
 
 	private releaseTimer: number;
 	private maxReleaseSequenceLength: number;
@@ -74,14 +74,13 @@ export class Inputs<T> {
 		setTimeout(() => {
 			const idx = this._releaseSequence.findIndex((i) => i === input);
 			this._releaseSequence.slice(idx);
-		}, this.releaseTimer)
-
+		}, this.releaseTimer);
 
 		this.cullSequences();
 	}
 
 	consume(input: Input<T>[]) {
-		for (let i of input) {
+		for (const i of input) {
 			const idx = this._inputSequence.findIndex((item) => item === i);
 			if (idx) {
 				this._inputSequence.splice(idx, 1);
@@ -94,21 +93,24 @@ export class Inputs<T> {
 		const group: T[] = [];
 		const pressed: T[] = [];
 
-		for (let i of this._inputSequence) {
+		for (const i of this._inputSequence) {
 			if (i.press) {
 				pressed.push(i.input);
 			} else {
-
 			}
 		}
-
-
 
 		return groups;
 	}
 
 	private cullSequences() {
-		this._inputSequence = cullSequence(this._inputSequence, this.maxInputSequenceLength);
-		this._releaseSequence = cullSequence(this._releaseSequence, this.maxReleaseSequenceLength);
+		this._inputSequence = cullSequence(
+			this._inputSequence,
+			this.maxInputSequenceLength,
+		);
+		this._releaseSequence = cullSequence(
+			this._releaseSequence,
+			this.maxReleaseSequenceLength,
+		);
 	}
 }

--- a/src/layers/keyboard.ts
+++ b/src/layers/keyboard.ts
@@ -1,4 +1,4 @@
-import type { Modifiers } from "../input";
+import type { Input, Modifiers } from "../input";
 import type { InputMan } from "../manager";
 import { addWindowEventListener } from "../util";
 
@@ -7,6 +7,22 @@ export interface Key {
 	key?: string;
 	/// The physical location of the key (based on U.S. QWERTY layout)
 	code?: string;
+}
+
+export class KeyInput implements Input<Key> {
+	input: Key;
+	press?: boolean
+	name: string;
+
+	constructor(key: Key, press?: boolean, name?: string) {
+		this.input = key;
+		this.press = press;
+		if (name) {
+			this.name = name;
+		} else {
+			this.name = key.code ?? key.key ?? "unknown";
+		}
+	}
 }
 
 export interface KeyboardLayerEvent {

--- a/src/layers/keyboard.ts
+++ b/src/layers/keyboard.ts
@@ -11,7 +11,7 @@ export interface Key {
 
 export interface KeyboardLayerEvent {
 	key: Key;
-	modifiers: Modifiers
+	modifiers: Modifiers;
 }
 
 export type KeyboardCallbackFn = (ev: KeyboardLayerEvent) => void;
@@ -88,8 +88,8 @@ export class KeyboardLayer {
 				alt: ev.altKey,
 				ctrl: ev.ctrlKey,
 				meta: ev.metaKey,
-			}
-		}
+			},
+		};
 		const filtered = this.callbacks.filter((c) => c.type === type);
 		filtered.forEach((cb) => cb.fn(event));
 	}

--- a/src/layers/keyboard.ts
+++ b/src/layers/keyboard.ts
@@ -128,7 +128,7 @@ export class KeyboardLayer {
 		this.manager.maybePreventDefault(ev);
 		this.pressedKeys.add({ key: ev.key, code: ev.code });
 		this.invokeCallbacks(ev, "keydown");
-		this.manager.pressInput({ input: ev.code, press: true });
+		this.manager.pressInput(ev.code);
 	}
 
 	private keyUp(ev: KeyboardEvent) {
@@ -137,7 +137,7 @@ export class KeyboardLayer {
 		this.keySequence.push({ key: ev.key, code: ev.code });
 		this.invokeCallbacks(ev, "keyup");
 		this.cullKeySequence();
-		this.manager.releaseInput({ input: ev.code, press: false });
+		this.manager.releaseInput(ev.code);
 	}
 
 	private cullKeySequence() {

--- a/src/layers/mouse.ts
+++ b/src/layers/mouse.ts
@@ -10,15 +10,12 @@ interface MouseState {
 	lastMove: Vector2;
 }
 
-export type MouseCallbackFn = (
-	ev: MouseLayerEvent,
-	state: MouseState,
-) => void;
+export type MouseCallbackFn = (ev: MouseLayerEvent, state: MouseState) => void;
 
 export interface MouseLayerEvent {
 	ev: MouseEvent | Event;
 	button?: string;
-	modifiers?: Modifiers
+	modifiers?: Modifiers;
 }
 
 export type MouseCallbackType =
@@ -69,7 +66,7 @@ export class MouseLayer {
 	}
 
 	get cursorLocked() {
-		return this._cursorLocked
+		return this._cursorLocked;
 	}
 
 	registerCallback(cb: MouseCallbackFn, type: MouseCallbackType) {
@@ -77,14 +74,14 @@ export class MouseLayer {
 	}
 
 	removeCallback(cb: MouseCallback) {
-		const idx = this.callbacks.filter((c) => c !== cb)
+		const idx = this.callbacks.filter((c) => c !== cb);
 	}
 
 	private invokeCallbacks(ev: MouseEvent | Event, type: MouseCallbackType) {
 		// We have two event types here, scroll (Event) and mouse button moves/clicks (MouseEvent)
 		// So we start by just filling out the event
-		let event: MouseLayerEvent = {
-			ev
+		const event: MouseLayerEvent = {
+			ev,
 		};
 		// And if its a MouseEvent we fill in all the additional details we have from that
 		if (ev instanceof MouseEvent) {
@@ -92,11 +89,11 @@ export class MouseLayer {
 				shift: ev.shiftKey,
 				alt: ev.altKey,
 				ctrl: ev.ctrlKey,
-				meta: ev.metaKey
-			}
+				meta: ev.metaKey,
+			};
 			// Before we set the button, we check its a mouse button event and not a mouse move event
 			if (type === "mousedown" || type === "mouseup") {
-				event.button = getMouseButtonName(ev.button)
+				event.button = getMouseButtonName(ev.button);
 			}
 		}
 		// Then we filter the callbacks for those which match the type of event we have

--- a/src/layers/mouse.ts
+++ b/src/layers/mouse.ts
@@ -106,13 +106,13 @@ export class MouseLayer {
 	private mouseDown(ev: MouseEvent) {
 		this.invokeCallbacks(ev, "mousedown");
 		const name = getMouseButtonName(ev.button);
-		this.manager.pressInput({ input: name, press: true });
+		this.manager.pressInput(name);
 	}
 
 	private mouseUp(ev: MouseEvent) {
 		this.invokeCallbacks(ev, "mouseup");
 		const name = getMouseButtonName(ev.button);
-		this.manager.releaseInput({ input: name, press: true });
+		this.manager.releaseInput(name);
 	}
 
 	private mouseMove(ev: MouseEvent) {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1,4 +1,5 @@
 import { Binding, createBinding, type BindingFn } from "./bindings";
+import { Inputs } from "./input";
 import { KeyboardLayer } from "./layers/keyboard";
 import { MouseLayer } from "./layers/mouse";
 
@@ -11,28 +12,17 @@ export interface InputManConfig {
 	sequenceTimer?: number;
 }
 
-export interface Input {
-	input: string;
-	press: boolean;
-}
-
 export class InputMan {
 	keyboard: KeyboardLayer;
 	mouse: MouseLayer;
 
-	private inputs: Array<Input> = [];
-
+	private inputs: Inputs<string>;
 	private preventsDefault: boolean;
-	private pressedInputs: Set<Input> = new Set();
-	inputSequence: Array<Input> = [];
-	private sequenceTimer: number;
-	private maxSequenceLength: number;
 	private bindings: Set<Binding> = new Set();
 
 	constructor(target: Window | HTMLElement, config?: InputManConfig) {
 		this.preventsDefault = config?.preventsDefault ?? true;
-		this.maxSequenceLength = config?.maxSequenceLength ?? 5;
-		this.sequenceTimer = config?.sequenceTimer ?? 200;
+		this.inputs = new Inputs({ maxInputSequenceLength: config?.maxSequenceLength, maxReleaseSequenceLength: config?.maxSequenceLength, releaseSequenceTimer: config?.sequenceTimer })
 
 		this.keyboard = new KeyboardLayer(this, target, config?.maxSequenceLength);
 		this.mouse = new MouseLayer(this, target);
@@ -49,7 +39,7 @@ export class InputMan {
 
 	private invokeBindings() {
 		for (const binding of this.bindings) {
-			if (binding.matches(Array.from(this.pressedInputs))) {
+			if (binding.matches(this.inputs.toBindingDescriptor(binding.descriptor.length))) {
 				binding.fn();
 			}
 		}
@@ -60,28 +50,13 @@ export class InputMan {
 		return this.preventsDefault;
 	}
 
-	pressInput(name: Input) {
-		this.pressedInputs.add(name);
+	pressInput(name: string) {
+		this.inputs.press({ name, input: name });
 		this.invokeBindings();
 	}
 
-	releaseInput(name: Input) {
-		this.pressedInputs.delete(name);
-		this.addToSequence(name);
+	releaseInput(name: string) {
+		this.inputs.unpress({ name, input: name });
 		this.invokeBindings();
-	}
-
-	private addToSequence(input: Input) {
-		this.inputSequence.push(input);
-		const idx = this.inputSequence.length - 1;
-		setTimeout(() => {
-			this.inputSequence.splice(idx, 1);
-		}, this.sequenceTimer);
-		if (this.inputSequence.length > this.maxSequenceLength) {
-			this.inputSequence = this.inputSequence.slice(
-				this.inputSequence.length - this.maxSequenceLength,
-				this.inputSequence.length,
-			);
-		}
 	}
 }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -48,26 +48,8 @@ export class InputMan {
 	}
 
 	private invokeBindings() {
-		const { sequential, consecutive } = Array.from(this.bindings).reduce(
-			(accumulator, curr) => {
-				if (curr.sequential) {
-					accumulator.sequential.push(curr);
-				} else {
-					accumulator.consecutive.push(curr);
-				}
-				return accumulator;
-			},
-			{ sequential: new Array<Binding>(), consecutive: new Array<Binding>() },
-		);
-
-		for (const binding of consecutive) {
+		for (const binding of this.bindings) {
 			if (binding.matches(Array.from(this.pressedInputs))) {
-				binding.fn();
-			}
-		}
-
-		for (const binding of sequential) {
-			if (binding.matches(this.inputSequence)) {
 				binding.fn();
 			}
 		}

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -11,7 +11,6 @@ export interface InputManConfig {
 	sequenceTimer?: number;
 }
 
-
 export interface Input {
 	input: string;
 	press: boolean;

--- a/src/util.ts
+++ b/src/util.ts
@@ -14,6 +14,27 @@ export function arrayContainsOrd<T>(outer: T[], inner: T[]): boolean {
 	return false;
 }
 
+export function arrayEqual2d<T>(a: T[][], b: T[][]): boolean {
+	if (a.length !== b.length) return false;
+
+	for (let i = 0; i < a.length; i++) {
+		// We know rowA is defined, so !
+		const rowA = a[i]!;
+		const rowB = b[i];
+
+		// If rowB is not defined, we already know the arrays are not equal
+		if (!rowB) return false;
+		// And if they have different lengths, they are also not equal
+		if (rowA.length !== rowB.length) return false;
+
+		for (let j = 0; j < rowA.length; j++) {
+			if (rowA[j] !== rowB[j]) return false;
+		}
+	}
+
+	return true
+}
+
 export function arraysEqual<T>(array1: T[], array2: T[]): boolean {
 	return (
 		array1.length === array2.length &&

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,3 +30,13 @@ export function addWindowEventListener<K extends keyof WindowEventMap>(
 ) {
 	window.addEventListener(type, listener);
 }
+
+export function cullSequence<T>(input: T[], maxLength: number): T[] {
+	if (input.length > maxLength) {
+		const len = input.length;
+		const start = len - maxLength;
+		input = input.slice(start, len);
+	}
+
+	return input;
+}

--- a/tests/bindings.test.ts
+++ b/tests/bindings.test.ts
@@ -48,13 +48,13 @@ test("Test parsing binding beginning with combinators", () => {
 });
 
 test("Test single binding creation", () => {
-	let binding = createBinding("KeyW", () => {});
+	let binding = createBinding("KeyW", () => { });
 
-	expect(binding?.keys).toStrictEqual([["KeyW"]]);
+	expect(binding?.descriptor).toStrictEqual([["KeyW"]]);
 });
 
 test("Test combination binding creation", () => {
-	let binding = createBinding("ShiftLeft+KeyW", () => {});
+	let binding = createBinding("ShiftLeft+KeyW", () => { });
 
-	expect(binding?.keys).toStrictEqual([["ShiftLeft", "KeyW"]]);
+	expect(binding?.descriptor).toStrictEqual([["ShiftLeft", "KeyW"]]);
 });

--- a/tests/bindings.test.ts
+++ b/tests/bindings.test.ts
@@ -1,15 +1,11 @@
 import { test, expect } from "vitest";
-import {
-	createBinding,
-	parseBinding,
-	splitBinding,
-} from "../src/bindings";
+import { createBinding, parseBinding, splitBinding } from "../src/bindings";
 
 test("Test splitting binding", () => {
 	const split = splitBinding("KeyD+KeyC>ShiftLeft");
 
 	expect(split).toStrictEqual(["KeyD", "+", "KeyC", ">", "ShiftLeft"]);
-})
+});
 
 test("Test parsing single key binding", () => {
 	let inputs = parseBinding("KeyD");
@@ -26,38 +22,39 @@ test("Test parsing multi-key binding", () => {
 test("Test parsing multi-key binding with spaces", () => {
 	let inputs = parseBinding("ShiftLeft + KeyD > KeyC");
 
-	expect(inputs).toStrictEqual([["ShiftLeft", "KeyD"], ["KeyC"]])
+	expect(inputs).toStrictEqual([["ShiftLeft", "KeyD"], ["KeyC"]]);
 });
 
 test("Test parsing complex multi-group binding", () => {
 	const binding = parseBinding("ShiftLeft+KeyD>ShiftLeft+KeyE+KeyC>KeyR");
 
-	expect(binding).toStrictEqual([["ShiftLeft", "KeyD"], ["ShiftLeft", "KeyE", "KeyC"], ["KeyR"]])
-})
+	expect(binding).toStrictEqual([
+		["ShiftLeft", "KeyD"],
+		["ShiftLeft", "KeyE", "KeyC"],
+		["KeyR"],
+	]);
+});
 
 test("Test parsing binding with duplicate combinators", () => {
 	const binding = parseBinding("ShiftLeft++KeyD+KeyC>>KeyE");
 
-	expect(binding).toStrictEqual([["ShiftLeft", "KeyD", "KeyC"], ["KeyE"]])
-})
+	expect(binding).toStrictEqual([["ShiftLeft", "KeyD", "KeyC"], ["KeyE"]]);
+});
 
 test("Test parsing binding beginning with combinators", () => {
 	const binding = parseBinding("+ShiftLeft>KeyE");
 
-	expect(binding).toStrictEqual([["ShiftLeft"], ["KeyE"]])
-})
+	expect(binding).toStrictEqual([["ShiftLeft"], ["KeyE"]]);
+});
 
 test("Test single binding creation", () => {
-	let binding = createBinding("KeyW", () => { });
+	let binding = createBinding("KeyW", () => {});
 
 	expect(binding?.keys).toStrictEqual([["KeyW"]]);
 });
 
-
 test("Test combination binding creation", () => {
-	let binding = createBinding("ShiftLeft+KeyW", () => { });
+	let binding = createBinding("ShiftLeft+KeyW", () => {});
 
 	expect(binding?.keys).toStrictEqual([["ShiftLeft", "KeyW"]]);
 });
-
-

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "vitest";
+import { Inputs } from "../src/input";
+import { KeyInput } from "../src/layers/keyboard";
+
+test("Test basic inputs to binding descriptor", () => {
+	const inputs = new Inputs();
+
+	inputs.press(new KeyInput({ code: "KeyD" }));
+
+	const b = inputs.toBindingDescriptor()
+
+	expect(b).toStrictEqual([["KeyD"]])
+})
+
+test("Test inputs to binding descriptor with sequential presses", () => {
+	const inputs = new Inputs();
+
+	inputs.press(new KeyInput({ code: "KeyD" }));
+	inputs.unpress(new KeyInput({ code: "KeyD" }));
+
+	inputs.press(new KeyInput({ code: "KeyE" }));
+
+	const b = inputs.toBindingDescriptor();
+
+	expect(b).toStrictEqual([["KeyD"], ["KeyE"]])
+});
+
+test("Test inputs to binding descriptor with multi-key groups", () => {
+	const inputs = new Inputs();
+
+	inputs.press(new KeyInput({ code: "KeyE" }));
+	inputs.press(new KeyInput({ code: "KeyD" }));
+
+	inputs.unpress(new KeyInput({ code: "KeyD" }));
+	inputs.press(new KeyInput({ code: "ShiftLeft" }));
+
+	const b = inputs.toBindingDescriptor();
+
+	expect(b).toStrictEqual([["KeyE", "KeyD"], ["KeyE", "ShiftLeft"]])
+})

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -7,7 +7,7 @@ test("Test basic inputs to binding descriptor", () => {
 
 	inputs.press(new KeyInput({ code: "KeyD" }));
 
-	const b = inputs.toBindingDescriptor()
+	const b = inputs.toBindingDescriptor(1)
 
 	expect(b).toStrictEqual([["KeyD"]])
 })
@@ -20,7 +20,7 @@ test("Test inputs to binding descriptor with sequential presses", () => {
 
 	inputs.press(new KeyInput({ code: "KeyE" }));
 
-	const b = inputs.toBindingDescriptor();
+	const b = inputs.toBindingDescriptor(2);
 
 	expect(b).toStrictEqual([["KeyD"], ["KeyE"]])
 });
@@ -34,7 +34,41 @@ test("Test inputs to binding descriptor with multi-key groups", () => {
 	inputs.unpress(new KeyInput({ code: "KeyD" }));
 	inputs.press(new KeyInput({ code: "ShiftLeft" }));
 
-	const b = inputs.toBindingDescriptor();
+	const b = inputs.toBindingDescriptor(2);
 
 	expect(b).toStrictEqual([["KeyE", "KeyD"], ["KeyE", "ShiftLeft"]])
+})
+
+test("Test correct handling of key releases in binding descriptor conversion", () => {
+	const inputs = new Inputs();
+
+	inputs.press(new KeyInput({ code: "ShiftLeft" }))
+	inputs.press(new KeyInput({ code: "Space" }));
+
+	inputs.unpress(new KeyInput({ code: "Space" }));
+	inputs.press(new KeyInput({ code: "KeyC" }));
+
+	const b = inputs.toBindingDescriptor(2);
+
+	expect(b).toStrictEqual([["ShiftLeft", "Space"], ["ShiftLeft", "KeyC"]])
+})
+
+test("Test inputs to complex binding descriptor", () => {
+	const inputs = new Inputs();
+
+	inputs.press(new KeyInput({ code: "KeyD" }));
+	inputs.press(new KeyInput({ code: "KeyB" }));
+	inputs.unpress(new KeyInput({ code: "KeyD" }));
+	inputs.unpress(new KeyInput({ code: "KeyB" }));
+	inputs.press(new KeyInput({ code: "KeyC" }))
+	inputs.unpress(new KeyInput({ code: "KeyC" }))
+
+
+	inputs.press(new KeyInput({ code: "ShiftLeft" }))
+	inputs.press(new KeyInput({ code: "Space" }))
+	inputs.press(new KeyInput({ code: "KeyR" }))
+
+	const b = inputs.toBindingDescriptor(3)
+
+	expect(b).toStrictEqual([["KeyD", "KeyB"], ["KeyC"], ["ShiftLeft", "Space", "KeyR"]]);
 })

--- a/tests/manager.browser.test.ts
+++ b/tests/manager.browser.test.ts
@@ -75,4 +75,4 @@ test("Test basic sequential binding", async () => {
 });
 
 // Unfortunately, we don't currently have a way to test mouse movement to my knowledge. Test is left as a reminder.
-test("Test mouse movement callbacks", async () => { });
+test("Test mouse movement callbacks", async () => {});

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "vitest";
-import { arrayContainsOrd } from "../src/util";
+import { arrayContainsOrd, cullSequence } from "../src/util";
 
 test("Test array contains ordered", () => {
 	expect(arrayContainsOrd([1, 2, 3, 4, 5], [1, 2, 3])).toStrictEqual(true);
@@ -10,3 +10,9 @@ test("Test array contains ordered", () => {
 		false,
 	);
 });
+
+test("Test sequence culling", () => {
+	const input = ["a", "b", "c", "d", "e"];
+
+	expect(cullSequence(input, 3)).toStrictEqual(["c", "d", "e"])
+})

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -14,5 +14,5 @@ test("Test array contains ordered", () => {
 test("Test sequence culling", () => {
 	const input = ["a", "b", "c", "d", "e"];
 
-	expect(cullSequence(input, 3)).toStrictEqual(["c", "d", "e"])
-})
+	expect(cullSequence(input, 3)).toStrictEqual(["c", "d", "e"]);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,16 +14,8 @@
 		"noImplicitOverride": true,
 		"module": "preserve",
 		"noEmit": true,
-		"lib": [
-			"es2022",
-			"dom",
-			"dom.iterable"
-		]
+		"lib": ["es2022", "dom", "dom.iterable"]
 	},
-	"include": [
-		"**/*.ts"
-	],
-	"exclude": [
-		"node_modules"
-	]
+	"include": ["**/*.ts"],
+	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
The `InputMan` class and the `KeyboardLayer` had a lot of duplicated code involving tracking keypresses, releases, and the sequence of inputs. This code was moved into a new generic `Inputs` class usable in the manager and any input layers. In addition, the new `Inputs` class supports parsing it's own input sequence into a `BindingDescriptor` to complete the move to the new binding system.